### PR TITLE
Fixes #62, aggiunge caching headers

### DIFF
--- a/_playbooks/site.yml
+++ b/_playbooks/site.yml
@@ -16,11 +16,23 @@
         server_name: "teamdigitale.governo.it"
         root: "{{ web_document_root }}"
         index: "index.html"
-
-  roles:
-    - { role: geerlingguy.nginx }
+        extra_parameters: |
+          expires $expires;
 
   tasks:
+    - name: "NGINX cache expire config map"
+      copy:
+        content: |
+          # Expires map
+          map $sent_http_content_type $expires {
+              default                    off;
+              text/html                  epoch;
+              text/css                   max;
+              application/javascript     max;
+              ~image/                    max;
+          }
+        dest: /etc/nginx/conf.d/expires_map.conf
+
     - name: "Document root directory"
       file:
         path: "{{ web_document_root }}"
@@ -28,3 +40,6 @@
         group: root
         state: directory
         mode: 0755
+
+  roles:
+    - { role: geerlingguy.nginx }


### PR DESCRIPTION
Looks good:

```
~ % http 156.54.180.141
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: no-cache
Connection: keep-alive
Content-Length: 0
Content-Type: text/html
Date: Wed, 22 Feb 2017 09:36:06 GMT
ETag: "58ad5a84-0"
Expires: Thu, 01 Jan 1970 00:00:01 GMT
Last-Modified: Wed, 22 Feb 2017 09:31:48 GMT
Server: nginx

~ % http 156.54.180.141/logo_16.png
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=315360000
Connection: keep-alive
Content-Length: 528
Content-Type: image/png
Date: Wed, 22 Feb 2017 09:36:13 GMT
ETag: "58ad5b65-210"
Expires: Thu, 31 Dec 2037 23:55:55 GMT
Last-Modified: Wed, 22 Feb 2017 09:35:33 GMT
Server: nginx
```