### PR TITLE
ho incluso video hackathon su pagina developers, ma non ho visto la preview

### DIFF
--- a/it/projects/developers.md
+++ b/it/projects/developers.md
@@ -60,6 +60,12 @@ roadmap aperte, documenti architetturali; contemporaneamente, stiamo incontrando
 "piattaforme abilitanti" (cioè tecnologie centrali importanti su cui costruire i servizi digitali) e stiamo avviando un percorso
 con loro per portare lo sviluppo dei progetti dentro Developers Italia.
 
+Da questo approccio è nato [Hack Developers](https://hack.developers.italia.it/), il più grande Hackathon dedicato ai servizi pubblici. Qui il video dell'evento che si è tenuto in decine di città italiane (e non solo!) ad ottobre 2017
+
+<blockquote class="twitter-video" data-lang="it"><p lang="it" dir="ltr">Cos&#39;è stato <a href="https://twitter.com/hashtag/HackDev17?src=hash&amp;ref_src=twsrc%5Etfw">#HackDev17</a>, il code sprint che il nostro Team <a href="https://twitter.com/developersITA?ref_src=twsrc%5Etfw">@developersITA</a> ha organizzato in tutta Italia, in collaborazione con <a href="https://twitter.com/CodemotionIT?ref_src=twsrc%5Etfw">@CodemotionIT</a> <a href="https://t.co/7giCzAALnK">pic.twitter.com/7giCzAALnK</a></p>&mdash; Team Digitale (@teamdigitaleIT) <a href="https://twitter.com/teamdigitaleIT/status/917058075877629954?ref_src=twsrc%5Etfw">8 ottobre 2017</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+
 
 {% include medium_project.html %}
 


### PR DESCRIPTION
Ho inserito un paio di righe di testo che introducono il video dell'hackathon
Ho incollato lo script twitter per l'embed del video, ma non ne ho potuta vedere la preview e non ho idea se sia ok
@rasky

<blockquote class="twitter-video" data-lang="it"><p lang="it" dir="ltr">Cos&#39;è stato <a href="https://twitter.com/hashtag/HackDev17?src=hash&amp;ref_src=twsrc%5Etfw">#HackDev17</a>, il code sprint che il nostro Team <a href="https://twitter.com/developersITA?ref_src=twsrc%5Etfw">@developersITA</a> ha organizzato in tutta Italia, in collaborazione con <a href="https://twitter.com/CodemotionIT?ref_src=twsrc%5Etfw">@CodemotionIT</a> <a href="https://t.co/7giCzAALnK">pic.twitter.com/7giCzAALnK</a></p>&mdash; Team Digitale (@teamdigitaleIT) <a href="https://twitter.com/teamdigitaleIT/status/917058075877629954?ref_src=twsrc%5Etfw">8 ottobre 2017</a></blockquote>
<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

Fixes issue #

Brief description of changes proposed in this pull request:

cc @teamdigitale/code-reviewers
cc @rasky 