### PR TITLE
Corretto titolo DAF

### DIFF
--- a/en/projects/daf.md
+++ b/en/projects/daf.md
@@ -1,5 +1,5 @@
 ---
-title: Data Analytics Framework (DAF)
+title: Data & Analytics Framework (DAF)
 lang: en
 permalink: /en/projects/daf.htm
 layout: project

--- a/it/projects/daf.md
+++ b/it/projects/daf.md
@@ -1,5 +1,5 @@
 ---
-title: Data Analytics Framework (DAF)
+title: Data & Analytics Framework (DAF)
 lang: it
 permalink: /it/projects/daf.htm
 layout: project


### PR DESCRIPTION
Corretto il titolo del progetto _Data & Analytics Framework_, sia nella pagina italiana che inglese. [Aggiunto & mancante]

cc @teamdigitale/code-reviewers

  