### PR TITLE
Added Pasceri to ANPR

### DIFF
--- a/en/projects/anpr.md
+++ b/en/projects/anpr.md
@@ -6,7 +6,7 @@ layout: project
 ref: anpr
 parent_ref: projects
 parent_menu: projects
-people: [carlo-contavalli, mirko-calvaresi, luca-bigliardi]
+people: [carlo-contavalli, mirko-calvaresi, luca-bigliardi, giuseppe-pasceri]
 toc: true
 medium_tag: anpr
 forum_category: anpr

--- a/it/projects/anpr.md
+++ b/it/projects/anpr.md
@@ -6,7 +6,7 @@ layout: project
 ref: anpr
 parent_ref: projects
 parent_menu: projects
-people: [carlo-contavalli, mirko-calvaresi, luca-bigliardi]
+people: [carlo-contavalli, mirko-calvaresi, luca-bigliardi, giuseppe-pasceri]
 toc: true
 medium_tag: anpr
 forum_category: anpr


### PR DESCRIPTION
Added Giuseppe Pasceri to ANPR project-page (ita + eng)


cc @teamdigitale/code-reviewers @mccalv @alessandrolinardi 
