### PR TITLE
Store built site in circleci artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ jobs:
           paths:
             - teamdigitale.governo.it
 
+      - store_artifacts:
+          path: /home/circleci/teamdigitale.governo.it/_site
+
   # Deploy to production site
   # Note that we need a custom SSH config to let rsync know
   # how to reach the production site.


### PR DESCRIPTION
We currently don't store any artifact in CircleCI; storing the built site is a good way to access a preview for each pull request.