### PR TITLE
PagoPA - timeline, aggiunto rilascio linee guida nuovo avviso cartaceo

### DIFF
--- a/en/projects/digital-payments.md
+++ b/en/projects/digital-payments.md
@@ -18,6 +18,9 @@ timeline:
     title: SDK mobile WISP 2.0 release
   - period: December 2017
     title: Pre-production release of WISP 2.0 and a mobile SDK, to be tested by Public Administrations
+  - period: June 2018
+    title: Release of the new paper notification's guidelines
+    status: todo
 twitter_tag: pagopa
 tweetdeck_id: 913421951103897600
 dashboard_url: https://dashboard.teamdigitale.governo.it/public/dashboard/d88a8ece-75ed-4668-ab8c-3a6c8693b4af

--- a/it/projects/pagamenti-digitali.md
+++ b/it/projects/pagamenti-digitali.md
@@ -18,6 +18,9 @@ timeline:
     title: Rilascio SDK mobile WISP 2.0
   - period: Dicembre 2017
     title: Rilascio in collaudo alle PA WISP 2.0 e SDK mobile
+  - period: Giugno 2018
+    title: Rilascio linee guida nuovo avviso cartaceo
+    status: todo
 twitter_tag: pagopa
 tweetdeck_id: 913421951103897600
 dashboard_url: https://dashboard.teamdigitale.governo.it/public/dashboard/2c8ee2ee-fa84-4dbf-8b6a-e7fb5f9ca950


### PR DESCRIPTION
Aggiunto rilascio linee guida nuovo avviso cartaceo in roadmap