### PR TITLE
Remove Piwik integration

### DIFF
--- a/_includes/layout_base.html
+++ b/_includes/layout_base.html
@@ -233,25 +233,6 @@
       ga('send', 'pageview');
     </script>
 
-    <!-- Piwik -->
-    <script type="text/javascript">
-      var _paq = _paq || [];
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u = "//italia.piwikpro.com/";
-        _paq.push(['setTrackerUrl', u + 'piwik.php']);
-        _paq.push(['setSiteId', 9]);
-        var d = document,
-          g = d.createElement('script'),
-          s = d.getElementsByTagName('script')[0];
-        g.type = 'text/javascript';
-        g.async = true;
-        g.defer = true;
-        g.src = u + 'piwik.js';
-        s.parentNode.insertBefore(g, s);
-      })();
-    </script>
     <!-- Twitter integration -->
     <script>
       window.twttr = (function(d, s, id) {
@@ -271,8 +252,6 @@
         return t;
       }(document, "script", "twitter-wjs"));
     </script>
-    <noscript><p><img src="//italia.piwikpro.com/piwik.php?idsite=9" style="border:0;" alt="piwikpro" /></p></noscript>
-    <!-- End Piwik Code -->
 
   </footer>
 


### PR DESCRIPTION
The Piwik account is now disabled and we are not using Piwik anymore, so we can safely remove this integration.