### PR TITLE
Pensionamento sito

### DIFF
--- a/_data/t.yml
+++ b/_data/t.yml
@@ -198,8 +198,8 @@ FormatDate:
   en: "%m/%d/%Y"
   it: "%d/%m/%Y"
 Current:
-  en: "current"
-  it: "a oggi"
+  en: "December 31, 2019"
+  it: "31 dicembre 2019"
 FromBlog:
   en: "From the blog"
   it: "Dal blog"
@@ -248,6 +248,9 @@ HomeBannerFuture:
 HomeBannerFutureSubtitle:
   en: "Last update: 30/09/2018"
   it: "Ultimo aggiornamento: 30/09/2018"
+HomeBannerIntro:
+  en: "The team of the <a href='/en/team'>Commissioner for the Digital Agenda</a> ended its mandate on December 31, 2019. Yet, the work goes on! The <a href='https://innovazione.gov.it/' target='_blank'>Minister for technological innovation and digitization</a>, Department for the digital transformation and PagoPA S.p.A. are in charge of managing the digital transformation projects"
+  it: "La struttura del <a href='/it/chi-siamo'>Commissario straordinario per l’attuazione dell’agenda digitale</a> ha concluso il suo mandato il 31 dicembre 2019, ma il nostro lavoro va avanti! I progetti di trasformazione digitale della Pubblica Amministrazione passano in gestione al <a href='https://innovazione.gov.it/' target='_blank'>Ministro per l’innovazione tecnologica e la digitalizzazione</a>, attraverso il Dipartimento per la trasformazione digitale e la società PagoPA S.p.A."
 SignatureFooter:
   en: ""
   it: "Il Team per la Trasformazione Digitale, salvo eccezioni, comunica con le altre Amministrazioni via posta elettronica ordinaria e non posta elettronica certificata, in conformità a quanto previsto dall’art.47 del Codice dell’Amministrazione Digitale."

--- a/_includes/home_banner.html
+++ b/_includes/home_banner.html
@@ -2,15 +2,16 @@
 {% assign projs_pages = same_lang_pages | where: "layout", "project" %}
 {% assign projs_last_modified = projs_pages | last_modified_sort | reverse | first %}
 {% assign projs_url = same_lang_pages | where: "ref", "projects" | first %}
-{% assign mission_url = same_lang_pages | where: "ref", "mission" | first %}
+{% assign team_url = same_lang_pages | where: "ref", "team" | first %}
 
 <div class="home-banner">
     <div class="container">
         <div class="col-md-6 col-lg-6">
-          <h2>{{ site.data.t.HomeBanner[page.lang]}}</h2><a href="{{mission_url.url | relative_url}}" class="read-more-link">{{ site.data.t.HomeBannerMore[page.lang]}}</a>
+          <h2>{{ site.data.t.HomeBanner[page.lang]}}</h2><a href="{{team_url.url | relative_url}}" class="read-more-link">{{ site.data.t.HomeBannerMore[page.lang]}}</a>
         </div>
         <div class="col-md-6 col-lg-6">
           <div class="home-banner__buttons">
+            {% comment %}
           <div  class="button projects-button">
             <a href="{{projs_url.url | relative_url}}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 42">
@@ -22,6 +23,7 @@
             </a>
           </div>
           <div></div>
+            {% endcomment %}
           <div  class="button report-button" >
             <a href="/{{page.lang}}/report.htm">
                 <svg viewBox="0 0 66 42" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -53,6 +55,11 @@
           </div>
 
         </div>
+        </div>
+        <div class="col-12">
+          <div class="button intro-button">
+            {{ site.data.t.HomeBannerIntro[page.lang]}}
+          </div>
         </div>
     </div>
 </div>

--- a/_includes/nav_side.html
+++ b/_includes/nav_side.html
@@ -18,6 +18,7 @@ tutte le pagine del sito che:
                   {% if menu_page.parent_ref == nil and menu_page.menu_position != nil %}
                   {% assign sub_pages_query = same_lang_pages | where: "parent_menu", menu_page.ref %}
                   {% assign sub_pages = sub_pages_query | sort: "title" %}
+                    {%- if menu_page.ref != "projects" and menu_page.ref != "join-us" -%}
                     <li class="sidenav-menu-item {{ menu_page.ref }}">
                       {% if sub_pages.size > 0 %}
                         <a href="#">{{ menu_page.title }}</a>
@@ -30,6 +31,7 @@ tutte le pagine del sito che:
                         <a href="{{ menu_page.url }}">{{ menu_page.title }}</a>
                         {% endif %}
                     </li>
+                    {%- endif -%}
                   {% endif %}
                 {% endfor %}
                 {% if page.lang=='en' %}

--- a/_includes/nav_top.html
+++ b/_includes/nav_top.html
@@ -4,8 +4,8 @@ tutte le pagine del sito che:
 - hanno la stessa lingua della pagina corrente
 - non hanno un "parent_ref" definito
 {% endcomment %}
-{% assign same_lang_pages = (site.html_pages | where: "lang", page.lang %}
-{% assign sorted_pages = (same_lang_pages | sort: "menu_position") %}
+{% assign same_lang_pages = site.html_pages | where: "lang", page.lang %}
+{% assign sorted_pages = same_lang_pages | sort: "menu_position" %}
 {% assign extra_menu = site.data.extra_menu %}
 <div class="container navbar-top-link positionRelative">
   <div class="row">
@@ -15,11 +15,12 @@ tutte le pagine del sito che:
         {% assign sub_pages_query = same_lang_pages | where: "parent_menu", menu_page.ref %}
         {% assign sub_pages = sub_pages_query | sort: "title" %}
         {% assign pagebytwo = sub_pages.size | divided_by:2 %}
-          {% if menu_page.ref == page.ref or menu_page.ref == page.parent_ref %}
-            {% assign isActive = true %}
-          {% else %}
-            {% assign isActive = false %}
-          {% endif %}
+        {% if menu_page.ref == page.ref or menu_page.ref == page.parent_ref %}
+          {% assign isActive = true %}
+        {% else %}
+          {% assign isActive = false %}
+        {% endif %}
+        {%- if menu_page.ref != "projects" and menu_page.ref != "join-us" -%}
           <div class="navbar-top-link__item positionRelative {{ menu_page.ref }}">
             <a href="{{ menu_page.url }}"
             {% if isActive %}class="active"{% endif %}
@@ -50,6 +51,7 @@ tutte le pagine del sito che:
               </div>
             {% endif %}
           </div>
+        {%- endif -%}
       {%- endif -%}
     {%- endfor -%}
     </div>

--- a/_sass/_teamdigitale.scss
+++ b/_sass/_teamdigitale.scss
@@ -966,7 +966,7 @@ body.layout-project {
 
   &__buttons {
     margin-top: 0.2em;
-    text-align: center;
+    text-align: right;
 
     & > br {
       @media screen and (max-width: 991px) {
@@ -1000,6 +1000,32 @@ body.layout-project {
 
     svg path {
       fill: white;
+    }
+  }
+
+  .intro-button {
+    margin: 4rem 1.2rem 0;
+    text-transform: none;
+
+    @media screen and (min-width: 992px) {
+      font-size: 1.8rem;
+      padding: 2rem 4rem;
+    }
+
+    &:hover {
+      color: #37474F;
+      background-color: #FFF;
+    }
+    a {
+      text-transform: none;
+      color: #37474F;
+      text-decoration: none;
+      font-size: inherit;
+      font-weight: bold;
+      padding: 0;
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 

--- a/en/join-us.md
+++ b/en/join-us.md
@@ -9,6 +9,7 @@ last_modified_by_layout: job
 redirect_from:
   - /join-us
   - /en/43-content.htm
+redirect_to: https://innovazione.gov.it/it/amministrazione-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/
 ---
 
 # Join us

--- a/en/people/andrea-biancini.md
+++ b/en/people/andrea-biancini.md
@@ -4,7 +4,6 @@ lang: en
 permalink: /en/people/andrea-biancini.html
 layout: people
 role: Open Source Project Leader
-is_new: true
 twitter_user: andreabiancini
 medium_user: andrea.biancini
 linkedin_url: https://www.linkedin.com/in/bianciniandrea/

--- a/en/projects/anpr.md
+++ b/en/projects/anpr.md
@@ -14,6 +14,7 @@ forum_limit: 3
 dashboard_daily: true
 twitter_tag: anpr
 dashboard_url: https://stato-migrazione.anpr.it?lang=en
+redirect_to: https://innovazione.gov.it/it/progetti/anpr/
 ---
 
 ### In short

--- a/en/projects/api.md
+++ b/en/projects/api.md
@@ -28,6 +28,7 @@ timeline:
     title: API Marketplace
     desc: First version of the API Catalog/Marketplace
     status: todo
+redirect_to: https://innovazione.gov.it/it/progetti/api/
 ---
 
 ### In short

--- a/en/projects/cad.md
+++ b/en/projects/cad.md
@@ -11,6 +11,7 @@ toc: true
 medium_tag: legislation
 forum_category:
 forum_limit: 3
+redirect_to: https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/
 ---
 
 ### In short

--- a/en/projects/cie.md
+++ b/en/projects/cie.md
@@ -13,6 +13,7 @@ forum_category: cie
 forum_limit: 3
 twitter_tag: cie
 dashboard_url: https://dashboard.pdnd.italia.it/public/dashboard/e155f9b3-7624-4e62-8b29-25e9f7d6dad5
+redirect_to: https://innovazione.gov.it/it/progetti/cie/
 ---
 
 ### In short

--- a/en/projects/daf.md
+++ b/en/projects/daf.md
@@ -32,6 +32,7 @@ timeline:
     title: Production release of the DAF
     desc: The Digital Team will draw up the procedures for the future owner of the DAF who will manage the operation and the evolution of the project. The owner of the DAF will take care of the interactions with the public administrations to define plans for incorporating their databases and usage cases. From time to time, they will define the data ingestion means and how the DAF is suited to its own activities.
     status: todo
+redirect_to: https://innovazione.gov.it/it/progetti/pdnd/
 ---
 
 ### In short

--- a/en/projects/designers.md
+++ b/en/projects/designers.md
@@ -12,6 +12,7 @@ twitter_user: DesignersITA
 medium_tag: design
 forum_category: design
 forum_limit: 3
+redirect_to: https://innovazione.gov.it/it/progetti/designers-italia/
 ---
 
 ### Overview 

--- a/en/projects/developers.md
+++ b/en/projects/developers.md
@@ -59,7 +59,7 @@ timeline:
     title: More tools for Public Administration
     desc: We intend to publish more tools and documentation for supporting Public Administrations in managing their open source projects according to the best practice.
     status: todo
-
+redirect_to: https://innovazione.gov.it/it/progetti/developers-italia/
 ---
 
 ### In short

--- a/en/projects/digital-citizenship.md
+++ b/en/projects/digital-citizenship.md
@@ -23,6 +23,7 @@ timeline:
   - period: End of 2019
     title: The app’s first public release in territories with the largest number of integrated services
     status: todo
+redirect_to: https://innovazione.gov.it/it/progetti/io/
 ---
 
 ### Overview

--- a/en/projects/digital-identity.md
+++ b/en/projects/digital-identity.md
@@ -13,6 +13,7 @@ forum_category: spid
 forum_limit: 3
 twitter_tag: spid
 dashboard_url: https://dashboard.pdnd.italia.it/public/dashboard/5b0da6d7-3bc9-42fd-be12-24b3be247550
+redirect_to: https://innovazione.gov.it/it/progetti/spid/
 ---
 
 ### In short

--- a/en/projects/digital-infrastructures.md
+++ b/en/projects/digital-infrastructures.md
@@ -13,6 +13,7 @@ forum_category: cloudpa
 twitter_tag: cloudpa
 forum_limit: 3
 dashboard_url: 
+redirect_to: https://innovazione.gov.it/it/progetti/cloud/
 ---
 
 ### Overview

--- a/en/projects/digital-payments.md
+++ b/en/projects/digital-payments.md
@@ -24,6 +24,7 @@ timeline:
   - period: January 2019
     title: Release WISP 2.0 for all Public Administration
 dashboard_url: https://dashboard.pdnd.italia.it/public/dashboard/d88a8ece-75ed-4668-ab8c-3a6c8693b4af
+redirect_to: https://innovazione.gov.it/it/progetti/pagopa/
 ---
 
 ### In short

--- a/en/projects/digital-transformation.md
+++ b/en/projects/digital-transformation.md
@@ -12,6 +12,7 @@ medium_tag: piano-triennale
 forum_category: piano-triennale
 forum_limit: 3
 twitter_tag: piano-triennale
+redirect_to: https://innovazione.gov.it/it/progetti/piano-triennale/
 ---
 
 ### In short

--- a/en/projects/docs.md
+++ b/en/projects/docs.md
@@ -35,6 +35,7 @@ timeline:
     title: Each organization may have a dedicated section for its documents
     desc: It will be possible to have a customized version of the Docs Italia interface for each institution
     status: todo
+redirect_to: https://docs.italia.it/
 ---
 
 ### In short

--- a/en/team.md
+++ b/en/team.md
@@ -13,18 +13,15 @@ redirect_from:
 
 ## About us
 
-The Digital Transformation Team was born to build the "operating system" of the
-country, a series of fundamental components on top of which we can build simpler
-and more efficient services for the citizens, the Public Administration and
-businesses, through innovative digital products.
+The Digital Transformation Team was born to build the "operating system" of the country, a series of fundamental components on top of which we can build simpler
+and more efficient services for the citizens, the Public Administration and businesses, through innovative digital products.
 
-The Commissioner's Team has been established on September 16, 2016 with an
-initial two-year mandate, up to September 16, 2018.   
+The Commissioner's Team was established on September 16, 2016 with an initial two-year mandate, up to September 16, 2018 under the guidance of Diego Piacentini.  
 The <a href="http://presidenza.governo.it/AmministrazioneTrasparente/DisposizioniGenerali/AttiGenerali/DpcmOrganismiCollegiali/DPCM_20160916_CommStraord_AgendaDigitale.pdf" title="Prime Minister Decree of Digital agenda commissarial structure" target="_blank">
-Digital Transformation Team</a> operated under a prorogatio regime until
-October 30, 2018.
+Digital Transformation Team</a> operated under a prorogatio regime until October 30, 2018.
 
-On October 25, 2018 the new Government Commissioner for the Digital Agenda was
-appointed and the Team’s mandate was extended. The Team will operate until December 31, 2019.
+On October 25, 2018 the new Government Commissioner for the Digital Agenda Luca Attias was appointed and the Team’s mandate was extended until December 31, 2019.
+
+At the end of 2019, the Team’s mandate ended, and from that point the projects will be held by the <a href='https://innovazione.gov.it/' target='_blank'>Department for digital transformation</a> of the Presidency of the Council of ministers and the <a href='https://www.pagopa.gov.it/' target='_blank'>PagoPA Spa</a> company.
 
 {% include team_list.html %}

--- a/it/chi-siamo.md
+++ b/it/chi-siamo.md
@@ -13,18 +13,13 @@ redirect_from:
 
 ## Chi siamo
 
-Il <a href="http://presidenza.governo.it/AmministrazioneTrasparente/DisposizioniGenerali/AttiGenerali/DpcmOrganismiCollegiali/DPCM_20160916_CommStraord_AgendaDigitale.pdf" title="Decreto del Presidente del Consiglio dei Ministri per la Struttura commissariale Agenda Digitale" target="_blank">
-Team per la Trasformazione Digitale</a> nasce per avviare la costruzione del
-“sistema operativo” del Paese, una serie di componenti fondamentali sui quali
-costruire servizi più semplici ed efficaci per i cittadini, la Pubblica
-Amministrazione e le imprese, attraverso prodotti digitali innovativi.
+Il <a href="http://presidenza.governo.it/AmministrazioneTrasparente/DisposizioniGenerali/AttiGenerali/DpcmOrganismiCollegiali/DPCM_20160916_CommStraord_AgendaDigitale.pdf" title="Decreto del Presidente del Consiglio dei Ministri per la Struttura commissariale Agenda Digitale" target="_blank">Team per la Trasformazione Digitale</a> è nato per avviare la costruzione del “sistema operativo” del Paese, una serie di componenti fondamentali sui quali costruire servizi più semplici ed efficaci per i cittadini, la Pubblica Amministrazione e le imprese, attraverso prodotti digitali innovativi.
   
-La struttura commissariale è stata istituita il 16 settembre 2016 con una
-scadenza iniziale al 16 settembre 2018.   
+La struttura commissariale è stata istituita il 16 settembre 2016 con una scadenza iniziale al 16 settembre 2018 sotto la guida di Diego Piacentini.  
 La struttura ha operato in regime di prorogatio fino al 30 ottobre 2018.
 
-Il 25 ottobre 2018 è stato nominato dalla Presidenza del Consiglio dei Ministri
-il nuovo Commissario Straordinario per l’attuazione dell’Agenda Digitale e la
-struttura è stata rinnovata. Il Team opererà fino al 31 dicembre 2019.
+Il 25 ottobre 2018 è stato nominato dalla Presidenza del Consiglio dei Ministri il nuovo Commissario Straordinario per l’attuazione dell’Agenda Digitale Luca Attias e la struttura è stata rinnovata fino al 31 dicembre 2019.
+
+Alla fine del 2019 la struttura commissariale ha concluso il suo mandato. I progetti del Team sono confluiti nel <a href='https://innovazione.gov.it/' target='_blank'>Dipartimento per la trasformazione digitale</a> della Presidenza del consiglio dei ministri e nella società <a href='https://www.pagopa.gov.it/' target='_blank'>PagoPA Spa</a>.
 
 {% include team_list.html %}

--- a/it/contatti.md
+++ b/it/contatti.md
@@ -10,8 +10,12 @@ redirect_from:
   - /contatti
   - /it/contatti.htm
 ---
+
+{% assign same_lang_pages = site.pages | where: "lang", page.lang %}
+{% assign team_page = same_lang_pages | where: "ref", "team" | first %}
+
 # Contatti
-Il Team per la Trasformazione Digitale della Presidenza del Consiglio è un [team piccolo e agile](https://teamdigitale.governo.it/it/47-content.htm) che lavora alla trasformazione digitale dei servizi pubblici italiani. Se vuoi proporre il tuo contributo e il tuo punto di vista sui progetti, qui trovi il nostro [forum](https://forum.italia.it/).
+Il Team per la Trasformazione Digitale della Presidenza del Consiglio è stato un [team piccolo e agile]({{team_page.url | relative_url}}) che ha lavorato alla trasformazione digitale dei servizi pubblici italiani. Se vuoi proporre il tuo contributo e il tuo punto di vista sui progetti, qui trovi il nostro [forum](https://forum.italia.it/).
 
 Vuoi scriverci?
 

--- a/it/join-us.md
+++ b/it/join-us.md
@@ -9,6 +9,7 @@ last_modified_by_layout: job
 redirect_from:
   - /lavora-con-noi
   - /it/36-content.htm
+redirect_to: https://innovazione.gov.it/it/amministrazione-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/
 ---
 # Lavora con noi
 

--- a/it/people/alessandro-sebastiani.md
+++ b/it/people/alessandro-sebastiani.md
@@ -4,7 +4,6 @@ lang: it
 permalink: /it/people/alessandro-sebastiani.html
 layout: people
 role: Software Developer
-is_new:
 twitter_user: sebbalex
 medium_user:
 linkedin_url: https://www.linkedin.com/in/alessandrosebastiani

--- a/it/people/alice-casiraghi.md
+++ b/it/people/alice-casiraghi.md
@@ -4,13 +4,12 @@ lang: it
 permalink: /it/people/alice-casiraghi.html
 layout: people
 role: UX designer
-is_new:
 twitter_user: 
 medium_user:
 linkedin_url: https://www.linkedin.com/in/alicecasiraghi
 ref: alice-casiraghi
 parent_ref: team
-start_date: 30 Aprile 2019
+start_date: 30 aprile 2019
 period_provided: fino al 31 dicembre 2019
 annual_compensation: € 80.000
 approved_by_court: Il decreto di nomina è in fase di registrazione presso la Corte dei Conti

--- a/it/people/andrea-biancini.md
+++ b/it/people/andrea-biancini.md
@@ -4,7 +4,6 @@ lang: it
 permalink: /it/people/andrea-biancini.html
 layout: people
 role: Open Source Project Leader
-is_new: true
 twitter_user: andreabiancini
 medium_user: andrea.biancini
 linkedin_url: https://www.linkedin.com/in/bianciniandrea/

--- a/it/people/andrea-carlini.md
+++ b/it/people/andrea-carlini.md
@@ -7,7 +7,7 @@ permalink: /it/people/andrea-carlini.htm
 ref: andrea-carlini
 parent_ref: team
 linkedin_url: https://www.linkedin.com/in/andrea-carlini-92676514/
-start_date: 1 Marzo 2019
+start_date: 1 marzo 2019
 period_provided: fino al 31 dicembre 2019
 annual_compensation: € 100.000
 approved_by_court: Il decreto di nomina è in fase di registrazione presso la Corte dei Conti

--- a/it/people/fabio-fumarola.md
+++ b/it/people/fabio-fumarola.md
@@ -13,7 +13,7 @@ start_date: 30 ottobre 2017
 end_date: 30 settembre 2018
 period_provided: fino al 16 settembre 2018
 annual_compensation: € 90,000
-approved_by_court: 30 Novembre 2017
+approved_by_court: 30 novembre 2017
 ---
 Avevo otto anni quando ho iniziato per caso programmare con un Commodore VIC-20 comprato dai miei genitori insieme ad un corso di inglese. Terminato il liceo scientifico, ho deciso di studiare Informatica all'Università di Bari.All'inizio era difficile, ma passate le prime difficoltà mi sono letteralmente innamorato di questa materia di studio. Mi sono laureato alla triennale e specialistica in cinque anni. Nel 2008, ho ricevuto un premio come miglior laureato  per la Facoltà di Scienze all'Università di Bari e infine deciso di iniziare un dottorato di ricerca in Machine Learning.
 

--- a/it/people/giuseppe-palestra.md
+++ b/it/people/giuseppe-palestra.md
@@ -13,7 +13,7 @@ start_date: 23 ottobre 2017
 end_date: 31 luglio 2018
 period_provided: 16 settembre 2018
 annual_compensation: € 60.000
-approved_by_court: 30 Novembre 2017
+approved_by_court: 30 novembre 2017
 ---
 Sono laureato in Informatica e Comunicazione Digitale, ho una Laurea Magistrale in Informatica con lode ed un Master di II livello in 'Sviluppo e Gestione di Data Center per il Calcolo Scientifico ad Alte Prestazioni'. Inoltre, nel 2017 ho ricevuto il titolo di dottore di ricerca (PhD) in Computer Science dal Dipartimento di Informatica dall'Università degli Studi di Bari “A. Moro”. Il focus della mia ricerca ha riguardato l'Intelligenza Artificiale e la Computer Vision. Ho partecipato a diversi corsi di alta formazione, summer school e conferenze.
 

--- a/it/people/leonardo-favario.md
+++ b/it/people/leonardo-favario.md
@@ -4,7 +4,6 @@ lang: it
 permalink: /it/people/leonardo-favario.html
 layout: people
 role: Open Source Project Leader
-is_new:
 twitter_user:
 medium_user:
 linkedin_url: https://www.linkedin.com/in/favario

--- a/it/people/matteo-boschi.md
+++ b/it/people/matteo-boschi.md
@@ -4,7 +4,6 @@ lang: it
 permalink: /it/people/matteo-boschi.html
 layout: people
 role: Mobile Developer
-is_new:
 twitter_user:
 medium_user:
 linkedin_url: https://www.linkedin.com/in/matteo-boschi

--- a/it/progetti.md
+++ b/it/progetti.md
@@ -6,6 +6,7 @@ menu_position: 3
 permalink: /it/progetti.htm
 layout: default
 last_modified_by_layout: project
+redirect_to: https://innovazione.gov.it/it/progetti/
 ---
 
 <h2>I Progetti</h2>

--- a/it/projects/anpr.md
+++ b/it/projects/anpr.md
@@ -14,6 +14,7 @@ forum_category: anpr
 forum_limit: 3
 dashboard_daily: true
 dashboard_url: https://stato-migrazione.anpr.it
+redirect_to: https://innovazione.gov.it/it/progetti/anpr/
 ---
 
 ### In breve

--- a/it/projects/api.md
+++ b/it/projects/api.md
@@ -28,6 +28,7 @@ timeline:
     title: Marketplace delle API
     desc: Prima versione del Catalogo / Marketplace delle API
     status: todo
+redirect_to: https://innovazione.gov.it/it/progetti/api/
 ---
 
 ### In breve

--- a/it/projects/cad.md
+++ b/it/projects/cad.md
@@ -11,7 +11,7 @@ toc: true
 medium_tag: legislation
 forum_category:
 forum_limit: 3
-
+redirect_to: https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/
 ---
 
 ### In breve

--- a/it/projects/cie.md
+++ b/it/projects/cie.md
@@ -13,6 +13,7 @@ twitter_tag: cie
 forum_category: cie
 forum_limit: 3
 dashboard_url: https://dashboard.pdnd.italia.it/public/dashboard/e155f9b3-7624-4e62-8b29-25e9f7d6dad5
+redirect_to: https://innovazione.gov.it/it/progetti/cie/
 ---
 
 ### In breve

--- a/it/projects/cittadinanza-digitale.md
+++ b/it/projects/cittadinanza-digitale.md
@@ -23,6 +23,7 @@ timeline:
   - period: Fine 2019
     title: Pubblicazione prima release pubblica nei territori con il maggior numero di servizi integrati
     status: todo
+redirect_to: https://innovazione.gov.it/it/progetti/io/
 ---
 
 ### In breve

--- a/it/projects/daf.md
+++ b/it/projects/daf.md
@@ -32,6 +32,7 @@ timeline:
     title: Messa in Produzione del DAF
     desc: Il Team digitale predispone le procedure atte al subentro del futuro owner del DAF che gestirà l’operatività e l’evoluzione del progetto. L’owner del DAF curerà le interazioni con le PA per definire piani di inclusione delle relative basi di dati e casi d’uso. Le PA di volta in volta coinvolte definiranno le modalità di ingestione dei dati e utilizzo del DAF consone alle proprie attività.
     status: todo
+redirect_to: https://innovazione.gov.it/it/progetti/pdnd/
 ---
 
 ### In breve

--- a/it/projects/designers.md
+++ b/it/projects/designers.md
@@ -12,6 +12,7 @@ twitter_user: DesignersITA
 medium_tag: design
 forum_category: design
 forum_limit: 3
+redirect_to: https://innovazione.gov.it/it/progetti/designers-italia/
 ---
 
 ### In breve

--- a/it/projects/developers.md
+++ b/it/projects/developers.md
@@ -59,6 +59,7 @@ timeline:
     title: Pubblicazione di ulteriori strumenti per le Pubbliche Amministrazioni
     desc: Entro il 2019 vogliamo completare tutti gli strumenti tecnici e la documentazione a supporto delle Pubbliche Amministrazioni per la corretta gestione dei propri progetti secondo il modello open source.
     status: todo
+redirect_to: https://innovazione.gov.it/it/progetti/developers-italia/
 ---
 
 ### In breve

--- a/it/projects/docs.md
+++ b/it/projects/docs.md
@@ -35,6 +35,7 @@ timeline:
     title: Ogni Ente potrà avere una sezione dedicata per i propri documenti
     desc: Sarà possibile avere una versione personalizzata dell'interfaccia di Docs Italia per ogni ente
     status: todo
+redirect_to: https://docs.italia.it/
 ---
 
 ### In breve

--- a/it/projects/identita-digitale.md
+++ b/it/projects/identita-digitale.md
@@ -13,6 +13,7 @@ forum_category: spid
 twitter_tag: spid
 forum_limit: 3
 dashboard_url: https://dashboard.pdnd.italia.it/public/dashboard/91369902-9c46-42e9-94c6-1a8b1c92d6c4
+redirect_to: https://innovazione.gov.it/it/progetti/spid/
 ---
 
 ### In breve

--- a/it/projects/infrastrutture-digitali.md
+++ b/it/projects/infrastrutture-digitali.md
@@ -12,6 +12,7 @@ medium_tag: cloudpa
 twitter_tag: cloudpa
 forum_category: piano-triennale/data-center-e-cloud
 forum_limit: 3
+redirect_to: https://innovazione.gov.it/it/progetti/cloud/
 ---
 
 ### In breve

--- a/it/projects/pagamenti-digitali.md
+++ b/it/projects/pagamenti-digitali.md
@@ -24,6 +24,7 @@ timeline:
   - period: Gennaio 2019
     title: Rilascio WISP 2.0 per tutte le Pubbliche Amministrazioni
 dashboard_url: https://dashboard.pdnd.italia.it/public/dashboard/2c8ee2ee-fa84-4dbf-8b6a-e7fb5f9ca950
+redirect_to: https://innovazione.gov.it/it/progetti/pagopa/
 ---
 
 ### In breve

--- a/it/projects/trasformazione-digitale.md
+++ b/it/projects/trasformazione-digitale.md
@@ -12,7 +12,7 @@ medium_tag: piano-triennale
 twitter_tag: piano-triennale
 forum_category: piano-triennale
 forum_limit: 3
-
+redirect_to: https://innovazione.gov.it/it/progetti/piano-triennale/
 ---
 
 ### In breve

--- a/it/repubblica-digitale.md
+++ b/it/repubblica-digitale.md
@@ -9,6 +9,7 @@ permalink: /it/repubblica-digitale
 redirect_from:
   - /repubblica-digitale
 hide_last_mod_date: true
+redirect_to: https://innovazione.gov.it/it/repubblica-digitale/
 ---
 
 <div class="container repubblica-digitale-header">


### PR DESCRIPTION
Questa PR implementa modifiche per la semplificazione e il posizionamento del sito da qui in avanti. In particolare:
- modifica la data di fine per i membri del team da "a oggi" al "31 Dicembre 2019"
- aggiunge un banner in homepage con un messaggio di chiarimento e link al sito MID
- nasconde i link a menu per le pagine "progetti" e "lavora con noi"
- aggiunge redirect puntuali al sito MID per le pagine di progetto, la pagina "progetti", la pagina "lavora con noi" e la pagina "repubblica digitale"
- modifica la pagina "Chi Siamo" modificando tempi verbali e aggiungendo maggiori dettagli